### PR TITLE
Add renewal button for expired monthly/yearly subscriptions

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
@@ -82,16 +82,16 @@ const MESSAGES: Messages = {
           <>
             If you don&apos;t renew it, it will disappear from your dashboard in
             90 days. To renew your expired subscription, purchase it again by
-            clicking <strong>Buy new subscription</strong>. Your token will
-            remain the same.
+            clicking the <strong>Renew Subscription</strong> button. Your token
+            will remain the same.
           </>
         ),
         [UserSubscriptionType.Yearly]: (
           <>
             If you don&apos;t renew it, it will disappear from your dashboard in
             90 days. To renew your expired subscription, purchase it again by
-            clicking <strong>Buy new subscription</strong>. Your token will
-            remain the same.
+            clicking the <strong>Renew Subscription</strong> button. Your token
+            will remain the same.
           </>
         ),
       },
@@ -112,16 +112,16 @@ const MESSAGES: Messages = {
           <>
             If you don&apos;t renew it, it will disappear from your dashboard in
             90 days. To renew your expired subscription, purchase it again by
-            clicking <strong>Buy new subscription</strong>. Your token will
-            remain the same.
+            clicking the <strong>Renew Subscription</strong> button. Your token
+            will remain the same.
           </>
         ),
         [UserSubscriptionType.Yearly]: (
           <>
             If you don&apos;t renew it, it will disappear from your dashboard in
             90 days. To renew your expired subscription, purchase it again by
-            clicking <strong>Buy new subscription</strong>. Your token will
-            remain the same.
+            clicking the <strong>Renew Subscription</strong> button. Your token
+            will remain the same.
           </>
         ),
       },

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -182,16 +182,26 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
               <>
                 {subscription.statuses.has_access_to_support &&
                 subscription.type !== UserSubscriptionType.Trial ? (
-                  <Button
-                    appearance="positive"
-                    className="p-subscriptions__details-action"
-                    data-test="support-button"
-                    disabled={editing}
-                    element="a"
-                    href="https://portal.support.canonical.com/"
-                  >
-                    Support portal
-                  </Button>
+                  <>
+                    <Button
+                      appearance="positive"
+                      className="p-subscriptions__details-action"
+                      data-test="support-button"
+                      disabled={editing}
+                      element="a"
+                      href="https://portal.support.canonical.com/"
+                    >
+                      Support portal
+                    </Button>
+                    {subscription.statuses.is_expired &&
+                      (subscription.type == "monthly" ||
+                        subscription.type == "yearly") && (
+                        <RenewalModal
+                          subscription={subscription}
+                          editing={editing}
+                        />
+                      )}
+                  </>
                 ) : null}
                 {subscription.statuses.is_renewable ? (
                   <RenewalModal subscription={subscription} editing={editing} />


### PR DESCRIPTION
## Done

- [List of work items including drive-bys.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes [#712](https://github.com/canonical/commercial-squad/issues/712)

## Screenshots

[If relevant, please include a screenshot.]
