### PR TITLE
Add checkbox for Ubuntu pro description

### DIFF
--- a/static/js/src/PurchaseModal/PurchaseModal.tsx
+++ b/static/js/src/PurchaseModal/PurchaseModal.tsx
@@ -200,6 +200,7 @@ const PurchaseModal = ({
                   content: (
                     <ConfirmAndBuy
                       termsLabel={termsLabel}
+                      descriptionLabel={descriptionLabel}
                       marketingLabel={marketingLabel}
                     />
                   ),

--- a/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
@@ -28,7 +28,10 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
   const genericPurchaseMutation = useMakePurchase();
 
   const isButtonDisabled =
-    !values.captchaValue || !values.TermsAndConditions || isLoading;
+    !values.captchaValue ||
+    !values.TermsAndConditions ||
+    !values.Description ||
+    isLoading;
 
   const buyAction = values.FreeTrial === "useFreeTrial" ? "trial" : action;
 
@@ -148,6 +151,7 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
         }
       }
       setFieldValue("MarketingOptIn", false);
+      setFieldValue("Description", false);
       setFieldValue("TermsAndConditions", false);
     }
   }, [purchaseError]);

--- a/static/js/src/PurchaseModal/components/ConfirmAndBuy/ConfirmAndBuy.tsx
+++ b/static/js/src/PurchaseModal/components/ConfirmAndBuy/ConfirmAndBuy.tsx
@@ -4,10 +4,15 @@ import { Row, Col, CheckboxInput } from "@canonical/react-components";
 
 type Props = {
   termsLabel: React.ReactNode;
+  descriptionLabel: React.ReactNode;
   marketingLabel: React.ReactNode;
 };
 
-const ConfirmAndBuy = ({ termsLabel, marketingLabel }: Props) => {
+const ConfirmAndBuy = ({
+  termsLabel,
+  descriptionLabel,
+  marketingLabel,
+}: Props) => {
   return (
     <Row>
       <Col size={12}>
@@ -15,6 +20,14 @@ const ConfirmAndBuy = ({ termsLabel, marketingLabel }: Props) => {
           as={CheckboxInput}
           name="TermsAndConditions"
           label={termsLabel}
+          defaultChecked={false}
+        />
+      </Col>
+      <Col size={12}>
+        <Field
+          as={CheckboxInput}
+          name="Description"
+          label={descriptionLabel}
           defaultChecked={false}
         />
       </Col>

--- a/static/js/src/PurchaseModal/utils/utils.ts
+++ b/static/js/src/PurchaseModal/utils/utils.ts
@@ -40,6 +40,7 @@ export interface FormValues {
   captchaValue: string | null;
   TermsAndConditions: boolean;
   MarketingOptIn: boolean;
+  Description: boolean;
   FreeTrial: string;
 }
 
@@ -91,6 +92,7 @@ function getInitialFormValues(
     captchaValue: null,
     TermsAndConditions: false,
     MarketingOptIn: false,
+    Description: false,
     FreeTrial: canBeTrialled ? "useFreeTrial" : "payNow",
   };
 }

--- a/static/js/src/advantage/offers/components/Offer/Offer.tsx
+++ b/static/js/src/advantage/offers/components/Offer/Offer.tsx
@@ -130,6 +130,7 @@ const Offer = ({ offer }: Props) => {
             termsLabel={termsLabel}
             product={product}
             quantity={items.length}
+            descriptionLabel={descriptionLabel}
             marketingLabel={marketingLabel}
             Summary={OfferSummary}
             closeModal={closePortal}

--- a/static/js/src/advantage/react/components/Subscriptions/RenewalModal/RenewalModal.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/RenewalModal/RenewalModal.tsx
@@ -99,6 +99,7 @@ const RenewalModal = ({ subscription, editing }: Props) => {
           <PurchaseModal
             termsLabel={termsLabel}
             marketingLabel={marketingLabel}
+            descriptionLabel={descriptionLabel}
             product={product}
             quantity={subscription.number_of_machines}
             Summary={RenewalSummary}

--- a/static/js/src/advantage/subscribe/blender/components/PaymentModal/PaymentModal.tsx
+++ b/static/js/src/advantage/subscribe/blender/components/PaymentModal/PaymentModal.tsx
@@ -53,6 +53,7 @@ export default function PaymentModal({ isHidden }: Props) {
         <Portal>
           <PurchaseModal
             termsLabel={termsLabel}
+            descriptionLabel={descriptionLabel}
             marketingLabel={marketingLabel}
             product={product}
             quantity={quantity}

--- a/static/js/src/advantage/subscribe/react/components/PaymentModal/PaymentModal.tsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentModal/PaymentModal.tsx
@@ -52,6 +52,7 @@ export default function PaymentModal({ isHidden }: Props) {
         <Portal>
           <PurchaseModal
             termsLabel={termsLabel}
+            descriptionLabel={descriptionLabel}
             marketingLabel={marketingLabel}
             product={product}
             quantity={sanitisedQuantity}

--- a/static/sass/_pattern_checkout.scss
+++ b/static/sass/_pattern_checkout.scss
@@ -1,19 +1,19 @@
 @mixin ubuntu-p-checkout {
   .checkout-container {
     background-color: white;
-    position: fixed;
-    top: 0;
-    z-index: 999;
-    width: 100vw;
     height: 100vh;
     overflow-y: scroll;
     padding: $sp-large 0;
+    position: fixed;
+    top: 0;
+    width: 100vw;
+    z-index: 999;
 
     .p-stepped-list--detailed {
       margin-left: 0;
     }
 
-    .email-field{
+    .email-field {
       display: flex;
       flex-direction: column;
     }


### PR DESCRIPTION
## Done

- Add checkbox for Ubuntu pro description
- Addressed "Confirm and buy is missing the new checkbox added by Min last week" Albert mentioned [here](https://github.com/canonical/ubuntu.com/pull/12013#issuecomment-1294738195)

## QA

<img width="631" alt="image" src="https://user-images.githubusercontent.com/57550290/199018608-3e3a26e3-e8da-4cf1-a719-5cfba8e37dae.png">
